### PR TITLE
🛠️ compilation added to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
-FROM openjdk:17
-COPY target/crud-0.0.1-SNAPSHOT.jar java-app.jar
-ENTRYPOINT [ "java", "-jar", "java-app.jar" ]
+# Usa la nueva imagen
+FROM maven:3.9.6-eclipse-temurin-17-focal
+# Crea carpeta /app para un mejor orden
+WORKDIR /app
+# Copia todo el proyecto al contenedor
+COPY . .
+# Maven limpia y compila el proyecto
+RUN mvn clean package -DskipTests
+# Ejecuta el archivo rar compilado
+ENTRYPOINT [ "java", "-jar", "target/crud-0.0.1-SNAPSHOT.jar" ]


### PR DESCRIPTION
![image](https://github.com/Doisaac/crud-daw/assets/53149834/c0b3f05d-7cff-4013-afd1-642f329ee181)

Now instead of using ***openjdk:17***, it uses ***maven:3.9.6-eclipse-temurin-17-focal*** compiling and cleaning automatically inside the container.

The *.jar* file path is **target/crud-0.0.1-SNAPSHOT.jar.**